### PR TITLE
[Debug] Fix #122 messagePart.charset not defined

### DIFF
--- a/Resources/views/Collector/swiftmailer.html.twig
+++ b/Resources/views/Collector/swiftmailer.html.twig
@@ -167,7 +167,7 @@
                         <div class="card-block">
                             <span class="label">Alternative part ({{ messagePart.contentType }})</span>
                             <pre>
-                                {%- if messagePart.charset %}
+                                {%- if messagePart.charset is defined and messagePart.charset %}
                                     {{- messagePart.body|convert_encoding('UTF-8', messagePart.charset) }}
                                 {%- else %}
                                     {{- messagePart.body }}


### PR DESCRIPTION
Fix for the error #122

`
Method "charset" for object "Swift_Attachment" does not exist in @Swiftmailer\Collector\swiftmailer.html.twig at line 170 
`

that prevented the debug panel from opening when attaching files to mails.

It was already done once (symfony/swiftmailer-bundle/pull/37) but came back with the new design.
